### PR TITLE
Add a section on custom component libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Written on top of Flask, Plotly.js, and React.js, Dash is ideal for building dat
 - [Talks](#talks)
 - [Galleries](#galleries)
 - [App Examples](#app-examples)
+- [Component Libraries](#component-libraries)
 - [Contributors](#contributors)
 
 ## Tutorials ##
@@ -51,6 +52,11 @@ Written on top of Flask, Plotly.js, and React.js, Dash is ideal for building dat
 - [3D Yield Curve](https://plot.ly/dash/gallery/yield-curve/) - Adapted from NYTimes's excellent [A 3-D View of a Chart That Predicts The Economic Future: The Yield Curve](https://www.nytimes.com/interactive/2015/03/19/upshot/3d-yield-curve-economic-growth.html). [Source Code.](https://github.com/plotly/dash-yield-curve)
 - [Finding Bigfoot](https://bigfoot-sightings-dash.herokuapp.com/) - Several plots (including a map), a grid layout built with Bootstrap, interactions with an input field, and caching (See also [Tutorials](#tutorials)). [Source Code.](https://github.com/timothyrenner/bigfoot-dash-app)
 - [Visualize Earthquakes with Plotly Dash](https://belle-croissant-54211.herokuapp.com/) - Great UI and usage of geospatial analytics with Dash. [Source Code.](https://github.com/jackdbd/dash-earthquakes)
+
+## Component Libraries ##
+- [Tutorial on creating custom Dash components with React.js](https://plot.ly/dash/plugins)
+- [Dash Core Components](https://github.com/plotly/dash-core-components)
+- [Dash HTML Components](https://github.com/plotly/dash-html-components)
 
 ## Contributors ##
 - [Luke Singham](http://lukesingham.com/)


### PR DESCRIPTION
There isn't yet a centralized place for community members to share the component libraries that they have created. This might be a good place to organize them.

I'm actually not aware of many component libraries that have been made by the community yet, so I don't have any other resources to put here besides the official dash component libraries that we maintain.