### PR TITLE
Add dash-vega-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A curated list of awesome Dash (plotly) resources
 - [dash-uploader](https://github.com/np-8/dash-uploader) - Upload component for Dash. Supports large data files.
 - [Dash Mantine Components](https://github.com/snehilvj/dash-mantine-components) - Collection of 40+ Dash components based on Mantine React Components library.
 - [plotly-resampler](https://github.com/predict-idlab/plotly-resampler) - Wrapper for plotly figures that adds data downsampling (aggregating) functionality, enabling the visualization of large datasets.
+- [dash-vega-components](https://github.com/altair-viz/dash-vega-components) - Dash component for Vega-Altair, Vega-Lite, and Vega charts
 
 ## App Examples
 - [Oil and Gas Explorer](https://plot.ly/dash/gallery/new-york-oil-and-gas/) - Explore oil and gas production over time and with linked visualisations. [Source Code.](https://github.com/plotly/dash-oil-and-gas-demo)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A curated list of awesome Dash (plotly) resources
 - [dash-uploader](https://github.com/np-8/dash-uploader) - Upload component for Dash. Supports large data files.
 - [Dash Mantine Components](https://github.com/snehilvj/dash-mantine-components) - Collection of 40+ Dash components based on Mantine React Components library.
 - [plotly-resampler](https://github.com/predict-idlab/plotly-resampler) - Wrapper for plotly figures that adds data downsampling (aggregating) functionality, enabling the visualization of large datasets.
-- [dash-vega-components](https://github.com/altair-viz/dash-vega-components) - Dash component for Vega-Altair, Vega-Lite, and Vega charts
+- [dash-vega-components](https://github.com/altair-viz/dash-vega-components) - Dash component for Vega-Altair, Vega-Lite, and Vega charts.
 
 ## App Examples
 - [Oil and Gas Explorer](https://plot.ly/dash/gallery/new-york-oil-and-gas/) - Explore oil and gas production over time and with linked visualisations. [Source Code.](https://github.com/plotly/dash-oil-and-gas-demo)


### PR DESCRIPTION
[dash-vega-components](https://github.com/altair-viz/dash-vega-components) is an official Vega-Altair project which is also featured in the [Plotly documentation](https://dash.plotly.com/dash-vega-components). You can use it to show Vega-Altair charts in your Dash app. It also supports callback triggering based on interactions with the charts.

### For first time contributors...

##### Do you want to be added to the contributors list on the README.md file?  
<!-- Check yes or no. If yes respond to the next 2 questions. If no, submit the pull request. -->
- [ ] Yes
- [x] No

##### What name would you like?
<!-- Add a name and link to your name to the README if you checked yes above.-->


##### What website would you like your name linked to?

  
